### PR TITLE
Change deep link to Action.Submit when opening task module

### DIFF
--- a/src/bots/teamsTalentMgmtBot.ts
+++ b/src/bots/teamsTalentMgmtBot.ts
@@ -1,4 +1,4 @@
-import { TeamsActivityHandler, TurnContext, UserState, Activity, SigninStateVerificationQuery, MessageFactory, AdaptiveCardInvokeResponse, AdaptiveCardInvokeValue, MessagingExtensionQuery, MessagingExtensionResponse, MessagingExtensionAction, MessagingExtensionActionResponse, FileConsentCardResponse, StatePropertyAccessor } from "botbuilder";
+import { TeamsActivityHandler, TurnContext, UserState, Activity, SigninStateVerificationQuery, MessageFactory, AdaptiveCardInvokeResponse, AdaptiveCardInvokeValue, MessagingExtensionQuery, MessagingExtensionResponse, MessagingExtensionAction, MessagingExtensionActionResponse, FileConsentCardResponse, StatePropertyAccessor, TaskModuleRequest, TaskModuleResponse } from "botbuilder";
 import { CommandBase } from "../commands/commandBase";
 import { HelpCommand } from "../commands/helpCommand";
 import { PositionDetailsCommand } from "../commands/positionDetailsCommand";
@@ -125,6 +125,16 @@ export class TeamsTalentMgmtBot extends TeamsActivityHandler {
     // if `initialRun` was set
     protected async handleTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
         return await this.invokeHandler.handleMessagingExtensionQuery(context, query, context.activity.channelData.source.name);
+    }
+
+    // Handles clicking an adaptive card button with `Action.Submit` _and_ `data/msteams/type = task/fetch`
+    protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+        return {
+            task: {
+                type: "continue",
+                value: await this.invokeHandler.handleTaskModuleFetch(taskModuleRequest)
+            }
+        }
     }
 
     // Handles clicking an adaptive card button with `Action.Execute`

--- a/src/services/data/templatingService.ts
+++ b/src/services/data/templatingService.ts
@@ -27,7 +27,6 @@ export class TemplatingService {
                 recruiters,
                 hasComments: candidate.comments && candidate.comments.length > 0,
                 status: status || "",
-                candidateFeedbackUrl: `https://teams.microsoft.com/l/task/${process.env.TeamsAppId}?url=${encodeURIComponent(`${process.env.BaseUrl}/StaticViews/CandidateFeedback.html?candidateId=${candidate.id}`)}&title=${encodeURIComponent(`Feedback for ${candidate.name}`)}&completionBotId=${process.env.MicrosoftAppId}&height=large&width=large`,
                 renderActions
             }
         });

--- a/src/services/invokeActivityHandler.ts
+++ b/src/services/invokeActivityHandler.ts
@@ -1,5 +1,5 @@
 import { parseBool } from "adaptivecards";
-import { AdaptiveCardInvokeResponse, Attachment, CardFactory, FileConsentCardResponse, InvokeResponse, MessageFactory, MessagingExtensionAction, MessagingExtensionActionResponse, MessagingExtensionAttachment, MessagingExtensionQuery, MessagingExtensionResponse, TurnContext } from "botbuilder";
+import { AdaptiveCardInvokeResponse, Attachment, CardFactory, FileConsentCardResponse, InvokeResponse, MessageFactory, MessagingExtensionAction, MessagingExtensionActionResponse, MessagingExtensionAttachment, MessagingExtensionQuery, MessagingExtensionResponse, TaskModuleRequest, TaskModuleTaskInfo, TurnContext } from "botbuilder";
 import { convertInvokeActionDataToComment, convertInvokeActionDataToInterview, convertInvokeActionDataToPosition, Position } from "./data/dtos";
 import { ServiceContainer } from "./data/serviceContainer";
 import { TokenProvider } from "./tokenProvider";
@@ -26,6 +26,24 @@ export class InvokeActivityHandler {
         return {
             status: 200
         };
+    }
+
+    public async handleTaskModuleFetch(taskModuleRequest: TaskModuleRequest): Promise<TaskModuleTaskInfo> {
+
+        const candidate = await this.services.candidateService.getById(taskModuleRequest.data.candidateId);
+
+        let baseUrl = <string>process.env.BaseUrl;
+
+        while(baseUrl.charAt(baseUrl.length-1)=="/") {
+            baseUrl = baseUrl.substring(0,baseUrl.length-1);
+        }
+
+        return {
+            url: `${baseUrl}/StaticViews/CandidateFeedback.html?candidateId=${candidate?.id}`,
+            title: `Feedback for ${candidate?.name}`,
+            width: "large",
+            height: "large"
+        }
     }
 
     public async handleMessagingExtensionSubmitAction(action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {

--- a/src/templates/candidateTemplate.json
+++ b/src/templates/candidateTemplate.json
@@ -184,10 +184,15 @@
             }
         },
         {
-            "type": "Action.OpenUrl",
+            "type": "Action.Submit",
             "title": "Open candidate feedback",
-            "url": "${candidateFeedbackUrl}",
-            "$when": "${hasComments}"
+            "$when": "${hasComments}",
+            "data":{
+                "candidateId": "${id}",
+                "msteams": {
+                    "type": "task/fetch"
+                }
+            }
         },
         {
             "type": "Action.ShowCard",


### PR DESCRIPTION
There seems to be a bug when opening a task module from an adaptive card with Action.Url and using the deep link url - changing this to Action.Submit and invoking the task/fetch handler is the current workaround.